### PR TITLE
feat: 모달 렌더링 portal 구현 및 modal layout 구현

### DIFF
--- a/Portal.tsx
+++ b/Portal.tsx
@@ -1,0 +1,14 @@
+import { ReactElement, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+function ModalPortal({ children }: { children: ReactElement }) {
+  const [portalElement, setPortalElement] = useState<HTMLElement | null>(null)
+
+  useEffect(() => {
+    setPortalElement(document.getElementById('modal'))
+  }, [])
+
+  return portalElement ? createPortal(children, portalElement) : null
+}
+
+export default ModalPortal

--- a/components/Modals/ModalLayout.tsx
+++ b/components/Modals/ModalLayout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function ModalLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="fixed top-0 z-50 flex h-screen w-full items-center justify-center bg-black/50">
+      <div className="h-auto w-[54rem] rounded-[0.8rem] bg-var-white p-[2.8rem]">{children}</div>
+    </div>
+  )
+}

--- a/contexts/ModalContext.tsx
+++ b/contexts/ModalContext.tsx
@@ -1,0 +1,55 @@
+import { ReactNode, createContext, useContext, useMemo, useReducer } from 'react'
+
+export type ModalState = {
+  [x: string]: boolean
+}
+
+export interface ContextValue {
+  modalState: ModalState
+  openModal: (modalName: string) => void
+  closeModal: (modalName: string) => void
+}
+
+interface ModalAction {
+  type: string
+  modalName: string
+}
+
+const ModalContext = createContext<ContextValue>({
+  modalState: {},
+  openModal: () => {},
+  closeModal: () => {},
+})
+
+const modalReducer = (state: ModalState, action: ModalAction) => {
+  switch (action.type) {
+    case 'OPEN_MODAL':
+      return { ...state, [action.modalName]: true }
+    case 'CLOSE_MODAL':
+      return { ...state, [action.modalName]: false }
+    default:
+      throw new Error(`unhandled action type: ${action.type}`)
+  }
+}
+
+export function ModalProvider({ children }: { children: ReactNode }) {
+  const [modalState, dispatch] = useReducer(modalReducer, {})
+
+  const openModal = (modalName: string) => {
+    dispatch({ type: 'OPEN_MODAL', modalName })
+  }
+
+  const closeModal = (modalName: string) => {
+    dispatch({ type: 'CLOSE_MODAL', modalName })
+  }
+
+  const modalHandler = useMemo(() => ({ modalState, openModal, closeModal }), [modalState])
+
+  return <ModalContext.Provider value={modalHandler}>{children}</ModalContext.Provider>
+}
+
+export const useModal = () => {
+  const { modalState, openModal, closeModal } = useContext(ModalContext)
+
+  return { modalState, openModal, closeModal }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { ModalProvider } from '@/contexts/ModalContext'
 import store from '@/store/store'
 import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
@@ -11,7 +12,9 @@ export default function App({ Component, pageProps }: AppProps) {
         <title>Taskify</title>
       </Head>
       <Provider store={store}>
-        <Component {...pageProps} />
+        <ModalProvider>
+          <Component {...pageProps} />
+        </ModalProvider>
       </Provider>
     </>
   )

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -7,6 +7,7 @@ export default function Document() {
       <body>
         <Main />
         <NextScript />
+        <div id="modal" />
       </body>
     </Html>
   )

--- a/pages/mydashboard.tsx
+++ b/pages/mydashboard.tsx
@@ -1,5 +1,7 @@
+import ModalPortal from '@/Portal'
 import { AppLayout } from '@/components'
 import InviteList from '@/components/InviteList/InviteList'
+import ModalLayout from '@/components/Modals/ModalLayout'
 import MyDashBoardList from '@/components/MyDashBoardList/MyDashBoardList'
 import Image from 'next/image'
 
@@ -29,6 +31,9 @@ export default function MyDashBoard() {
           )}
         </div>
       </div>
+      <ModalPortal>
+        <ModalLayout />
+      </ModalPortal>
     </AppLayout>
   )
 }


### PR DESCRIPTION
<img width="1552" alt="스크린샷 2024-06-03 오후 3 47 07" src="https://github.com/Taskify-2team/Taskify/assets/137033202/b0cbab70-b08e-4c00-bc99-89f8d1c0bb8e">
모달 레이아웃 만들었고 포탈까지 구현했습니다.
포탈 사용법은

```typescript
import ModalPortal from '@/Portal'
...
      <ModalPortal>
        <렌더링할 모달 />
      </ModalPortal>
...
```
이런 방식으로 사용하시면 됩니다. 그리고 모달 열고 닫는 로직은 useModal에 useReducer로 구현해놨습니다. 그래서 원하는 페이지에
```typescript
const {modalState, openModal, closeModal} = useModal()
```
로 불러와서 버튼 이벤트에 
```typescript
openModal('모달 상태(이름)')
```
함수 넣어서 동작하고
```typescript
closeModal('모달 상태(이름)')
```
으로 모달 닫아주시면 됩니다. 궁금하신 점은 물어보시면 다시 알려드리겠습니다.