### PR TITLE
fix: shortbutton 컴포넌트 통합, props로 색상 변경

### DIFF
--- a/components/Buttons/ShortButton.tsx
+++ b/components/Buttons/ShortButton.tsx
@@ -1,0 +1,22 @@
+interface ShortButtonProps {
+  text: string
+  color: 'white' | 'purple'
+  onClick: () => void
+}
+
+export default function ShortButton({ text, color, onClick }: ShortButtonProps) {
+  const colorVariants = {
+    white:
+      'border border-solid border-[--gray-gray_D9D9D9] bg-[--white-white_FFFFFF] text-[--violet-violet_5534DA]',
+    purple: 'bg-[--violet-violet_5534DA] text-[--white-white_FFFFFF]',
+  }
+
+  return (
+    <span
+      onClick={onClick}
+      className={`${colorVariants[color]} inline-block w-[8.4rem] cursor-pointer rounded-[0.4rem] py-[0.7rem] text-center text-[1.4rem] leading-tight`}
+    >
+      {text}
+    </span>
+  )
+}

--- a/components/InviteList/InviteList.tsx
+++ b/components/InviteList/InviteList.tsx
@@ -1,11 +1,11 @@
 import Image from 'next/image'
-import { PurpleButton, WhiteButton } from '@/components'
 import searchIcon from '@/public/icons/searchIcon.svg'
 import emptyIcon from '@/public/icons/emptyDashBoard.svg'
 import { useEffect, useRef, useState } from 'react'
 import { Invitation } from '@/types/invitation'
 import { getInvitationList } from '@/service/invitations'
 import useAsync from '@/hooks/useAsync'
+import { ShortButton } from '..'
 
 export default function InviteList() {
   const [invitationList, setInvitationList] = useState<Invitation[]>([])
@@ -67,8 +67,8 @@ export default function InviteList() {
             <p className="text-[1.6rem]">{item.dashboard.title}</p>
             <p className="text-[1.6rem]">{item.inviter.nickname}</p>
             <div className="flex justify-center gap-[1rem]">
-              <PurpleButton text="수락" />
-              <WhiteButton text="거절" />
+              <ShortButton text="수락" color="purple" onClick={() => console.log(1)} />
+              <ShortButton text="거절" color="white" onClick={() => console.log(1)} />
             </div>
           </div>
         ))}

--- a/components/index.ts
+++ b/components/index.ts
@@ -76,6 +76,7 @@ import CreateTodoButton from './Buttons/CreateTodoButton'
 import DeleteBoardButton from './Buttons/DeleteBoardButton'
 import LongButton from './Buttons/LongButton'
 import PaginationButton from './Buttons/PaginationButton'
+import ShortButton from './Buttons/ShortButton'
 
 export {
   PurpleButton,
@@ -88,6 +89,7 @@ export {
   DeleteBoardButton,
   LongButton,
   PaginationButton,
+  ShortButton,
 }
 
 /** Modal Components */


### PR DESCRIPTION
shortbutton 컴포넌트를 한개로 통일했습니다 props로 버튼에 들어갈 text와 color, onclick 이벤트 보내주시면 됩니다.
color는 white, purple 두개만 받도록 설정해서 문자열로 지정해주시면 됩니다.
```typescript
  <ShortButton text="수락" color="purple" onClick={() => console.log(1)} />
  <ShortButton text="거절" color="white" onClick={() => console.log(1)} />
```
위의 예시처럼 사용해주시면 됩니다. 우선 이전 컴포넌트는 남겨놨으니 나중에 수정해주시면 됩니당