### PR TITLE
dashboard 페이지 컬럼별 스크롤, 반응형 구현

### DIFF
--- a/components/AppLayout/AppLayout.tsx
+++ b/components/AppLayout/AppLayout.tsx
@@ -15,7 +15,7 @@ export default function AppLayout({ children }: AppLayoutProps) {
       <div className="flex min-h-[100vh] bg-var-gray1">
         <SideMenu />
         <div
-          className={`w-full pl-[30rem] pt-[8rem] sm:pl-[6.5rem] md:pl-[16rem] ${theme === 'normal' ? 'bg-var-gray1' : 'bg-var-black3'} transition ease-linear`}
+          className={`w-full pl-[30rem] pt-[7rem] sm:pl-[6.5rem] md:pl-[16rem] ${theme === 'normal' ? 'bg-var-gray1' : 'bg-var-black3'} transition ease-linear`}
         >
           {children}
         </div>

--- a/components/AppLayout/DashboardLayout/DashboardLayout.tsx
+++ b/components/AppLayout/DashboardLayout/DashboardLayout.tsx
@@ -42,7 +42,7 @@ export default function DashboardLayout({ dashboardId }: DashboardLayoutProps) {
   }
 
   return (
-    <div className="flex overflow-auto">
+    <div className="flex">
       {columnList?.map((column) => (
         <DashBoardColumn
           key={column.id}
@@ -53,7 +53,7 @@ export default function DashboardLayout({ dashboardId }: DashboardLayoutProps) {
           drop={drop}
         />
       ))}
-      <section className="w-[35.4rem] p-[2rem] pt-[7.2rem]">
+      <section className="p-[2rem] pt-[7.2rem]">
         <CreateColumnButton
           onClick={() => {
             dispatch(openModal({ modalName: 'AddColumn', modalProps: { dashboardId } }))

--- a/components/AppLayout/DashboardLayout/DashboardLayout.tsx
+++ b/components/AppLayout/DashboardLayout/DashboardLayout.tsx
@@ -42,7 +42,7 @@ export default function DashboardLayout({ dashboardId }: DashboardLayoutProps) {
   }
 
   return (
-    <div className="flex">
+    <div className="flex sm:w-full sm:flex-col">
       {columnList?.map((column) => (
         <DashBoardColumn
           key={column.id}

--- a/components/AppLayout/DashboardLayout/components/DashBoardCard.tsx
+++ b/components/AppLayout/DashboardLayout/components/DashBoardCard.tsx
@@ -38,7 +38,7 @@ export default function DashBoardCard({
     <button
       type="button"
       onClick={handleOpenModal}
-      className={`w-[31.4rem] animate-slideDown rounded-[0.6rem] border-[0.1rem] p-[2rem] outline-[0.1rem] hover:border-var-blue ${theme === 'normal' ? 'border-var-gray3 bg-var-white' : 'border-var-black2 bg-var-black2'}`}
+      className={`w-[31.4rem] max-w-[100%] animate-slideDown rounded-[0.6rem] border-[0.1rem] p-[2rem] hover:border-var-blue ${theme === 'normal' ? 'border-var-gray3 bg-var-white' : 'border-var-black2 bg-var-black2'}`}
       draggable
       onDragStart={() => dragStart(card, columnId)}
       onDragEnd={() => drop()}

--- a/components/AppLayout/DashboardLayout/components/DashBoardCard.tsx
+++ b/components/AppLayout/DashboardLayout/components/DashBoardCard.tsx
@@ -38,7 +38,7 @@ export default function DashBoardCard({
     <button
       type="button"
       onClick={handleOpenModal}
-      className={`w-[31.4rem] max-w-[100%] animate-slideDown rounded-[0.6rem] border-[0.1rem] p-[2rem] hover:border-var-blue ${theme === 'normal' ? 'border-var-gray3 bg-var-white' : 'border-var-black2 bg-var-black2'}`}
+      className={`w-[100%] animate-slideDown rounded-[0.6rem] border-[0.1rem] p-[2rem] hover:border-var-blue ${theme === 'normal' ? 'border-var-gray3 bg-var-white' : 'border-var-black2 bg-var-black2'}`}
       draggable
       onDragStart={() => dragStart(card, columnId)}
       onDragEnd={() => drop()}

--- a/components/AppLayout/DashboardLayout/components/DashBoardColumn.tsx
+++ b/components/AppLayout/DashboardLayout/components/DashBoardColumn.tsx
@@ -74,22 +74,24 @@ export default function DashBoardColumn({
           )
         }
       />
-      {cardList && (
-        <div className="flex flex-col gap-[1.6rem]">
-          {cardList.length > 0 &&
-            cardList.map((cardItem: Card) => (
-              <DashBoardCard
-                key={cardItem.id}
-                columnTitle={columnTitle}
-                card={cardItem}
-                columnId={columnId}
-                dragStart={dragStart}
-                drop={drop}
-              />
-            ))}
-          <div ref={obsRef} />
-        </div>
-      )}
+      <div className="w-full overflow-y-auto" style={{ maxHeight: 'calc(100vh - 225px)' }}>
+        {cardList && (
+          <div className="flex flex-col gap-[1.6rem]">
+            {cardList.length > 0 &&
+              cardList.map((cardItem: Card) => (
+                <DashBoardCard
+                  key={cardItem.id}
+                  columnTitle={columnTitle}
+                  card={cardItem}
+                  columnId={columnId}
+                  dragStart={dragStart}
+                  drop={drop}
+                />
+              ))}
+            <div style={{ height: '1px' }} ref={obsRef} />
+          </div>
+        )}
+      </div>
     </section>
   )
 }

--- a/components/AppLayout/DashboardLayout/components/DashBoardColumn.tsx
+++ b/components/AppLayout/DashboardLayout/components/DashBoardColumn.tsx
@@ -59,7 +59,7 @@ export default function DashBoardColumn({
 
   return (
     <section
-      className="flex w-[35.4rem] flex-col gap-[1.6rem] border-r border-r-var-gray2 p-[2rem]"
+      className="flex w-[35.4rem] flex-col gap-[1.6rem] border-r border-r-var-gray2 p-[2rem] sm:w-full"
       onDragEnter={() => dragEnter(columnId)}
       onDragOver={(e) => e.preventDefault()}
     >
@@ -74,9 +74,12 @@ export default function DashBoardColumn({
           )
         }
       />
-      <div className="w-full overflow-y-auto" style={{ maxHeight: 'calc(100vh - 225px)' }}>
+      <div
+        className="w-full overflow-y-auto sm:!max-h-[50rem]"
+        style={{ maxHeight: 'calc(100vh - 225px)' }}
+      >
         {cardList && (
-          <div className="flex flex-col gap-[1.6rem]">
+          <div className="flex flex-col gap-[1.6rem] sm:w-full">
             {cardList.length > 0 &&
               cardList.map((cardItem: Card) => (
                 <DashBoardCard

--- a/components/Buttons/CreateColumnButton.tsx
+++ b/components/Buttons/CreateColumnButton.tsx
@@ -10,7 +10,7 @@ export default function CreateColumnButton({ onClick }: ButtonHTMLAttributes<HTM
     <button
       type="button"
       onClick={onClick}
-      className={`flex h-[7rem] w-[54.4rem] cursor-pointer items-center justify-center gap-[1.2rem] rounded-[0.6rem] border border-solid ${theme === 'normal' ? 'bg-var-white' : 'border-var-black2 bg-var-black2'} lg:w-[35.4rem]`}
+      className={`flex h-[7rem] w-[35.4rem] cursor-pointer items-center justify-center gap-[1.2rem] rounded-[0.6rem] border border-solid ${theme === 'normal' ? 'bg-var-white' : 'border-var-black2 bg-var-black2'} lg:w-[35.4rem]`}
     >
       <p
         className={`text-nowrap text-[1.8rem] font-bold ${theme === 'normal' ? 'text-var-black' : 'text-var-white'}`}

--- a/pages/dashboard/[dashboardId]/index.tsx
+++ b/pages/dashboard/[dashboardId]/index.tsx
@@ -23,7 +23,7 @@ export default function Dashboard() {
 
   return (
     <AppLayout>
-      <div className="flex h-full overflow-auto">
+      <div className="flex h-full w-full overflow-auto">
         <DashboardLayout dashboardId={Number(dashboardId)} />
       </div>
     </AppLayout>


### PR DESCRIPTION
- [x] dashboard 컬럼별로 스크롤되도록 수정

<img width="1256" alt="스크린샷 2024-06-13 오후 1 18 35" src="https://github.com/Taskify-2team/Taskify/assets/105799083/0d402318-60f3-4b92-8e8a-cbc9ccd3ee4a">

- [x] dashboard 페이지 반응형 구현 

<img width="370" alt="스크린샷 2024-06-13 오후 1 19 54" src="https://github.com/Taskify-2team/Taskify/assets/105799083/28acfbd8-6ffe-4d16-b168-f1084ac88b1c">
