### PR TITLE
refactor-textarea 최대 입력 제한

### DIFF
--- a/components/Inputs/CommentItem.tsx
+++ b/components/Inputs/CommentItem.tsx
@@ -82,9 +82,9 @@ export default function CommentItem({ comment, authorId, onUpdate, onDelete }: C
             </div>
           </form>
         ) : (
-          <div>
+          <div className="w-full">
             <p
-              className={`whitespace-pre-wrap text-[1.4rem] ${theme === 'normal' ? 'text-var-black2' : 'text-var-gray3'}`}
+              className={`whitespace-pre-wrap break-words text-[1.4rem] ${theme === 'normal' ? 'text-var-black2' : 'text-var-gray3'}`}
             >
               {comment.content}
             </p>

--- a/components/Inputs/InputLayout.tsx
+++ b/components/Inputs/InputLayout.tsx
@@ -18,7 +18,7 @@ export default function InputLayout({
   const { theme } = useLoadTheme()
 
   return (
-    <label htmlFor={id} className="flex flex-col gap-[1rem]">
+    <label htmlFor={id} className="relative flex flex-col gap-[1rem]">
       <span
         className={`${isSmallSize ? 'text-[1.6rem]' : 'text-[1.8rem]'} leading-tight ${theme === 'normal' ? 'text-var-black4' : 'text-var-gray3'}`}
       >

--- a/components/Inputs/Textarea.tsx
+++ b/components/Inputs/Textarea.tsx
@@ -1,6 +1,7 @@
 import { InputHTMLAttributes } from 'react'
 import { useLoadTheme } from '@/store/context/ThemeContext'
 import InputLayout from './InputLayout'
+import TextCounter from '../TextCounter/TextCounter'
 
 interface TextareaProps extends InputHTMLAttributes<HTMLTextAreaElement> {
   label: string
@@ -27,8 +28,10 @@ export default function Textarea({
         onChange={onChange}
         placeholder={placeholder}
         required={isRequired}
+        maxLength={250}
         className={`input-layout h-[9.6rem] resize-none ${theme === 'dark' && 'border-var-black1 bg-var-black1 text-var-gray3'}`}
       />
+      <TextCounter text={String(value)} />
     </InputLayout>
   )
 }

--- a/components/TextCounter/TextCounter.tsx
+++ b/components/TextCounter/TextCounter.tsx
@@ -1,0 +1,13 @@
+interface TextCounterProps {
+  text: string
+}
+
+export default function TextCounter({ text }: TextCounterProps) {
+  return (
+    <div className="absolute bottom-[-2rem] right-0">
+      <p
+        className={`${text.length === 250 ? 'text-var-red' : 'text-var-black4'} text-[1.2rem]`}
+      >{`${text.length}/250`}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
<img width="518" alt="스크린샷 2024-06-13 오후 9 44 44" src="https://github.com/Taskify-2team/Taskify/assets/137033202/1405ad92-75a9-444e-9763-8da01e3c42b0">
글자수 표현하는 컴포넌트 만들었습니다. 확인해보니까 textarea 입력하는 부분이 250자까지 리퀘스트가 보내져서 우선 250으로 설정했습니다.
지금은 카드 추가하는 부분에만 적용했는데 댓글부분에 적용하면 좋을것 같습니다