### PR TITLE
대시보드 헤더 반응형 수정

### DIFF
--- a/components/AppLayout/DashboardLayout/components/DashBoardColumn.tsx
+++ b/components/AppLayout/DashboardLayout/components/DashBoardColumn.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import useAsync from '@/hooks/useAsync'
 import { Card } from '@/types/dashboard'
 import { useAppDispatch, useAppSelector } from '@/hooks/useApp'
+import { useLoadTheme } from '@/store/context/ThemeContext'
 import { openModal } from '@/store/reducers/modalReducer'
 
 interface DashBoardColumnProps {
@@ -21,6 +22,7 @@ export default function DashBoardColumn({
   dragEnter,
   drop,
 }: DashBoardColumnProps) {
+  const { theme } = useLoadTheme()
   const cardList = useAppSelector((state) => state.card.cardList[columnId])
   const cursorId = useAppSelector((state) => state.card.cursorId[columnId])
   const { cardListStatus } = useAppSelector((state) => state.card)
@@ -59,7 +61,7 @@ export default function DashBoardColumn({
 
   return (
     <section
-      className="flex w-[35.4rem] flex-col gap-[1.6rem] border-r border-r-var-gray2 p-[2rem] sm:w-full sm:gap-[1rem] sm:border-b sm:px-[1.2rem] sm:py-[1.7rem]"
+      className={`flex w-[35.4rem] flex-col gap-[1.6rem] border-r p-[2rem] sm:w-full sm:gap-[1rem] sm:border-b sm:px-[1.2rem] sm:py-[1.7rem] ${theme === 'normal' ? 'border-var-gray2' : 'border-var-black2'}`}
       onDragEnter={() => dragEnter(columnId)}
       onDragOver={(e) => e.preventDefault()}
     >

--- a/components/Buttons/CreateColumnButton.tsx
+++ b/components/Buttons/CreateColumnButton.tsx
@@ -10,7 +10,7 @@ export default function CreateColumnButton({ onClick }: ButtonHTMLAttributes<HTM
     <button
       type="button"
       onClick={onClick}
-      className={`flex h-[7rem] w-[35.4rem] cursor-pointer items-center justify-center gap-[1.2rem] rounded-[0.6rem] border border-solid sm:w-full ${theme === 'normal' ? 'bg-var-white' : 'border-var-black2 bg-var-black2'} lg:w-[35.4rem]`}
+      className={`flex h-[7rem] w-[35.4rem] cursor-pointer items-center justify-center gap-[1.2rem] rounded-[0.6rem] border border-solid sm:w-full ${theme === 'normal' ? 'border-var-gray3 bg-var-white' : 'border-var-black2 bg-var-black2'} lg:w-[35.4rem]`}
     >
       <p
         className={`text-nowrap text-[1.8rem] font-bold ${theme === 'normal' ? 'text-var-black' : 'text-var-white'}`}

--- a/components/Headers/DashBoardHeader/DashBoardHeader.tsx
+++ b/components/Headers/DashBoardHeader/DashBoardHeader.tsx
@@ -127,7 +127,7 @@ export default function DashBoardHeader() {
             handleOnClick={handleSetTheme}
           />
           {isButtonVisible && (
-            <div className="flex gap-[1.6rem] pr-[1.5rem] sm:gap-[1.7rem] sm:pr-0">
+            <div className="flex gap-[1.6rem] pr-[1.5rem] sm:flex-col sm:items-center sm:gap-[2.7rem] sm:pr-0">
               {createdByMe && (
                 <div className="flex gap-[1.6rem] sm:flex-col sm:gap-[1rem]">
                   <HeaderButton
@@ -164,7 +164,7 @@ export default function DashBoardHeader() {
             </div>
           )}
           <div
-            className="relative flex cursor-pointer items-center border-l-2 border-var-gray3 pl-[3.2rem] sm:border-none sm:pl-0 sm:pl-[1rem]"
+            className="relative flex cursor-pointer items-center border-l-2 border-var-gray3 pl-[3.2rem] sm:border-none sm:pl-0"
             onClick={toggleDropdown}
             ref={dropdownRef}
           >

--- a/components/Headers/DashBoardHeader/DashBoardHeader.tsx
+++ b/components/Headers/DashBoardHeader/DashBoardHeader.tsx
@@ -106,9 +106,9 @@ export default function DashBoardHeader() {
         </ModalPortal>
       )}
       <div
-        className={`fixed z-50 flex w-[100vw] items-center justify-between sm:pr-[2rem] ${theme === 'normal' ? 'border-var-gray3 bg-var-white pl-[2.4rem]' : 'border-var-black2 bg-var-black2 text-white'} py-[1.5rem] pl-[34rem] pr-[8rem] shadow sm:justify-end sm:pl-[8rem] sm:pr-[0.5rem] md:justify-between md:pl-[20rem] md:pr-[4rem]`}
+        className={`fixed z-50 flex w-[100vw] items-center justify-between sm:pr-[2rem] ${theme === 'normal' ? 'border-var-gray3 bg-var-white pl-[2.4rem]' : 'border-var-black2 bg-var-black2 text-white'} py-[1.5rem] pl-[34rem] pr-[8rem] shadow sm:pl-[8rem] sm:pr-[0.5rem] md:justify-between md:pl-[20rem] md:pr-[4rem]`}
       >
-        <div className="flex items-center gap-[0.6rem] sm:hidden">
+        <div className="flex items-center gap-[0.6rem]">
           <p className="flex h-[3.8rem] items-center text-[2rem] font-bold">{title}</p>
           {createdByMe && (
             <Image
@@ -118,7 +118,9 @@ export default function DashBoardHeader() {
             />
           )}
         </div>
-        <div className="flex gap-[1.6rem] sm:gap-[1rem]">
+        <div
+          className={`flex gap-[1.6rem] sm:fixed sm:bottom-0 sm:left-0 sm:z-[100] sm:h-[100vh] sm:w-[6.7rem] sm:flex-col sm:items-center sm:justify-end sm:gap-[1rem] sm:border-r-[0.1rem] sm:pb-[1.5rem] ${theme === 'normal' ? 'sm:border-var-gray3 sm:bg-var-white' : 'sm:border-var-black3 sm:bg-var-black2'}`}
+        >
           <HeaderButton
             buttonIcon={theme === 'normal' ? themeIcon : themeIconWhite}
             buttonName="테마"
@@ -127,7 +129,7 @@ export default function DashBoardHeader() {
           {isButtonVisible && (
             <div className="flex gap-[1.6rem] pr-[1.5rem] sm:gap-[1.7rem] sm:pr-0">
               {createdByMe && (
-                <div className="flex gap-[1.6rem] sm:gap-[1rem]">
+                <div className="flex gap-[1.6rem] sm:flex-col sm:gap-[1rem]">
                   <HeaderButton
                     buttonIcon={theme === 'normal' ? settingIcon : settingIconWhite}
                     buttonName="관리"
@@ -162,7 +164,7 @@ export default function DashBoardHeader() {
             </div>
           )}
           <div
-            className="relative flex cursor-pointer items-center border-l-2 border-var-gray3 pl-[3.2rem] sm:pl-[1rem]"
+            className="relative flex cursor-pointer items-center border-l-2 border-var-gray3 pl-[3.2rem] sm:border-none sm:pl-0 sm:pl-[1rem]"
             onClick={toggleDropdown}
             ref={dropdownRef}
           >

--- a/components/Headers/DashBoardHeader/ProfileList/ProfileList.tsx
+++ b/components/Headers/DashBoardHeader/ProfileList/ProfileList.tsx
@@ -39,26 +39,26 @@ export default function ProfileList({ theme, members, totalCount, LogInId }: Pro
     return (
       <div className="cursor-pointer">
         <div
-          className="ml-[2rem] flex w-[rem] items-center justify-center sm:ml-[1rem]"
+          className="ml-[2rem] flex w-[rem] items-center justify-center sm:ml-0 sm:w-fit sm:flex-col"
           onClick={toggleDropdown}
         >
           {members
             .slice(0, 3)
             .filter((member) => member.userId !== LogInId)
             .map((member) => (
-              <div key={member.id} className="ml-[-1.5rem]">
+              <div key={member.id} className="ml-[-1.5rem] sm:ml-0 sm:mt-[-1.5rem]">
                 <UserProfile nickname={member.nickname} profileImageUrl={member.profileImageUrl} />
               </div>
             ))}
           {totalCount > 3 && (
-            <div className="ml-[-1.5rem] flex h-[3.8rem] w-[3.8rem] items-center justify-center rounded-full bg-gray-400 text-[1.6rem] text-var-white">
+            <div className="ml-[-1.5rem] flex h-[3.8rem] w-[3.8rem] items-center justify-center rounded-full bg-gray-400 text-[1.6rem] text-var-white sm:ml-0 sm:mt-[-1.5rem]">
               +{totalCount - 3}
             </div>
           )}
         </div>
         {isDropdownOpen && (
           <div
-            className={`h-100% absolute mt-[0.8rem] animate-slideDown rounded-md border bg-white ${
+            className={`h-100% absolute mt-[0.8rem] animate-slideDown rounded-md border bg-white sm:bottom-[1rem] sm:left-[6rem] sm:mt-0 ${
               theme === 'normal' ? 'border-var-gray3' : 'border-var-black1 bg-var-black1 text-white'
             }shadow-lg`}
           >
@@ -70,7 +70,7 @@ export default function ProfileList({ theme, members, totalCount, LogInId }: Pro
               }`}
             >
               {members.slice((currentPage - 1) * pageSize, currentPage * pageSize).map((member) => (
-                <div key={member.id} className="px-[2rem] py-[1rem]">
+                <div key={member.id} className="px-[2rem] py-[1rem] sm:px-[1rem]">
                   <UserInfo nickname={member.nickname} profileImageUrl={member.profileImageUrl} />
                 </div>
               ))}

--- a/components/Headers/DashBoardHeader/buttons/HeaderButton.tsx
+++ b/components/Headers/DashBoardHeader/buttons/HeaderButton.tsx
@@ -8,7 +8,7 @@ export default function HeaderButton({ buttonIcon, buttonName, handleOnClick }: 
   return (
     <button
       type="button"
-      className={`flex shrink-0 items-center gap-[0.3rem] rounded-xl border border-solid px-[1.6rem] sm:px-[0.8rem] md:px-[0.8rem] ${theme === 'normal' ? 'border-[#d9d9d9] bg-var-white' : 'border-var-black1 bg-var-black1'}`}
+      className={`flex shrink-0 items-center gap-[0.3rem] rounded-xl border border-solid px-[1.6rem] sm:p-[0.8rem] md:px-[0.8rem] ${theme === 'normal' ? 'border-[#d9d9d9] bg-var-white' : 'border-var-black1 bg-var-black1'}`}
       onClick={() => {
         if (handleOnClick) {
           handleOnClick()

--- a/components/Headers/HeaderDropDown.tsx
+++ b/components/Headers/HeaderDropDown.tsx
@@ -14,7 +14,7 @@ function Dropdown({ theme }: DropdownProps) {
 
   return (
     <div
-      className={`absolute left-[1rem] top-[4.5rem] flex w-[11rem] animate-slideDown flex-col overflow-hidden rounded-md border border-solid p-[0.5rem] text-center sm:left-[-4.5rem] sm:w-[10rem] md:left-[0.5rem] ${
+      className={`absolute left-[1rem] top-[4.5rem] flex w-[11rem] animate-slideDown flex-col overflow-hidden rounded-md border border-solid p-[0.5rem] text-center sm:left-[5rem] sm:top-[-9rem] sm:w-[10rem] md:left-[0.5rem] ${
         theme === 'normal'
           ? 'border-var-gray3 bg-var-white'
           : 'border-var-black1 bg-var-black1 text-white'

--- a/components/Headers/HeaderDropDown.tsx
+++ b/components/Headers/HeaderDropDown.tsx
@@ -14,7 +14,7 @@ function Dropdown({ theme }: DropdownProps) {
 
   return (
     <div
-      className={`absolute left-[1rem] top-[4.5rem] flex w-[11rem] animate-slideDown flex-col overflow-hidden rounded-md border border-solid p-[0.5rem] text-center sm:w-[9rem] md:left-[0.5rem] ${
+      className={`absolute left-[1rem] top-[4.5rem] flex w-[11rem] animate-slideDown flex-col overflow-hidden rounded-md border border-solid p-[0.5rem] text-center sm:left-[-4.5rem] sm:w-[10rem] md:left-[0.5rem] ${
         theme === 'normal'
           ? 'border-var-gray3 bg-var-white'
           : 'border-var-black1 bg-var-black1 text-white'

--- a/components/SideMenu/SideMenu.tsx
+++ b/components/SideMenu/SideMenu.tsx
@@ -49,7 +49,7 @@ export default function SideMenu() {
 
   return (
     <div
-      className={`fixed z-50 flex h-[100vh] w-[30rem] flex-col border-r-2 ${theme === 'normal' ? 'border-var-gray3 bg-var-white' : 'border-var-black3 bg-var-black2'} px-[2.4rem] pt-[2rem] sm:w-[6.7rem] sm:items-center sm:px-[1rem] md:w-[16rem] md:px-[1.3rem]`}
+      className={`fixed z-50 flex h-[100vh] w-[30rem] flex-col border-r-2 sm:h-fit sm:border-none ${theme === 'normal' ? 'border-var-gray3 bg-var-white' : 'border-var-black3 bg-var-black2'} px-[2.4rem] pt-[2rem] sm:w-[6.7rem] sm:items-center sm:bg-transparent sm:px-[1rem] md:w-[16rem] md:px-[1.3rem]`}
     >
       <Link href="/mydashboard" className="flex w-fit items-center gap-[0.5rem]">
         <Image


### PR DESCRIPTION
- [x] 대시보드 헤더에 제목 보이고, 다른 버튼들 사이드메뉴로 이동

<img width="442" alt="스크린샷 2024-06-14 오후 4 18 10" src="https://github.com/Taskify-2team/Taskify/assets/105799083/7d557738-fbc0-4dc7-81c5-e33a857cfd95">

- [x] 기타 반응형 UI 수정