### PR TITLE
fix : 무한 스크롤 리퀘스트 사이즈 변수화로 null강제 삽입으로 임시처방

### DIFF
--- a/components/AppLayout/DashboardLayout/components/DashBoardColumn.tsx
+++ b/components/AppLayout/DashboardLayout/components/DashBoardColumn.tsx
@@ -75,6 +75,7 @@ export default function DashBoardColumn({
   useEffect(() => {
     const observer = new IntersectionObserver(handleObserver, { threshold: 0 })
     if (obsRef.current && cardListStatus !== 'pending' && cursorId) observer.observe(obsRef.current)
+
     return () => {
       observer.disconnect()
     }

--- a/constants/number.ts
+++ b/constants/number.ts
@@ -1,0 +1,2 @@
+/* eslint-disable import/prefer-default-export */
+export const CARD_REQUEST_SIZE = 6

--- a/service/cards.ts
+++ b/service/cards.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import { Card, CardList, PostCard, UpdateCard } from '@/types/dashboard'
+import { CARD_REQUEST_SIZE } from '@/constants/number'
 import axios from './instance'
 
 export const postDashBoardCard = async (props: PostCard) => {
@@ -17,7 +18,9 @@ export const getCardList = createAsyncThunk<CardList, { cursorId: number; column
   'card/getCardList',
   async ({ cursorId, columnId }) => {
     const cursorIdParam = cursorId ? `&cursorId=${cursorId}` : ''
-    const response = await axios.get(`/cards?size=6&columnId=${columnId}${cursorIdParam}`)
+    const response = await axios.get(
+      `/cards?size=${CARD_REQUEST_SIZE}&columnId=${columnId}${cursorIdParam}`,
+    )
     return response.data
   },
 )

--- a/store/reducers/cardReducer.ts
+++ b/store/reducers/cardReducer.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-param-reassign */
+import { CARD_REQUEST_SIZE } from '@/constants/number'
 import { getCardList, updateCard } from '@/service/cards'
 import { Card } from '@/types/dashboard'
 import { createSlice } from '@reduxjs/toolkit'
@@ -48,15 +49,18 @@ const cardSlice = createSlice({
           columnId = card.columnId
           if (!state.cardList[columnId]) {
             state.cardList[columnId] = []
-            state.cardList[columnId] = [...state.cardList[columnId], card]
           }
           const foundIndex = state.cardList[columnId].findIndex((v: Card) => v.id === card.id)
           if (foundIndex === -1) {
-            state.cardList[columnId] = [...state.cardList[columnId], card]
+            state.cardList[columnId].push(card)
           } else {
             state.cardList[columnId][foundIndex] = card
           }
-          state.cursorId[columnId] = action.payload.cursorId || null
+          if (action.payload.totalCount === CARD_REQUEST_SIZE) {
+            state.cursorId[columnId] = null
+          } else {
+            state.cursorId[columnId] = action.payload.cursorId || null
+          }
           state.totalCount[columnId] = action.payload.totalCount || '0'
         })
       })
@@ -71,13 +75,12 @@ const cardSlice = createSlice({
         const { columnId } = action.payload
         if (!state.cardList[columnId]) {
           state.cardList[columnId] = []
-          state.cardList[columnId] = [...state.cardList[columnId], action.payload]
         }
         const foundIndex = state.cardList[columnId].findIndex(
           (v: Card) => v.id === action.payload.id,
         )
         if (foundIndex === -1) {
-          state.cardList[columnId] = [...state.cardList[columnId], action.payload]
+          state.cardList[columnId].push(action.payload)
         } else {
           state.cardList[columnId][foundIndex] = action.payload
         }


### PR DESCRIPTION
불러올 데이터가 더 없는데도 커서아이디를 줘서 스토어 내부에서 버그가 생긴듯 합니다.
constants폴더에 number라는 파일에다 CARD_REQUEST_SIZE = 6 이라는 상수를 만들어서 카드 불러오는 리퀘스트와 스토어에서 사용,
무한 루프 버그는 리스폰스에 totalCount와 CARD_REQUEST_SIZE가 같다면 cursorId에 null 을 넣는것으로 일단은 해결 하였습니다. 근데 뭔가 찝찝